### PR TITLE
implements edit routing & duplicate + delete map modals

### DIFF
--- a/client/src/components/modals/DeleteMapModal.tsx
+++ b/client/src/components/modals/DeleteMapModal.tsx
@@ -1,0 +1,22 @@
+import { Modal, Button, Group } from "@mantine/core";
+import React from "react";
+
+interface DeleteMapModalProps {
+    opened: boolean;
+    onClose: () => void;
+  }
+
+const DeleteMapModal: React.FC<DeleteMapModalProps> =({opened, onClose}) => {
+  return (
+    <>
+      <Modal opened={opened} onClose={onClose} title="Delete Map?" centered size="auto">
+        <Group justify="space-between">
+          <Button variant="light">Delete</Button>
+          <Button variant="filled">Confirm</Button>
+        </Group>
+      </Modal>
+    </>
+  );
+}
+
+export default DeleteMapModal;

--- a/client/src/components/modals/DuplicateMapModal.tsx
+++ b/client/src/components/modals/DuplicateMapModal.tsx
@@ -1,0 +1,81 @@
+import { Modal, Button, Group, Box, TextInput, Stack, Select, Divider, Textarea } from "@mantine/core";
+import React from "react";
+import { useForm } from "@mantine/form";
+
+interface DuplicateMapModalProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+const DuplicateMapModal: React.FC<DuplicateMapModalProps> = ({ opened, onClose }) => {
+  const form = useForm({
+    initialValues: {
+      mapName: '',
+      description: '',
+      visibility: '',
+    },
+
+    validate: {
+      mapName: (value) => {
+        if (value.trim() === "") {
+          return "Map name is required";
+        }
+        return null;         // Return `null` if it's valid, or an error message if it's invalid
+      },
+      description: (value) => {
+        if (value.trim() === "") {
+          return "Description is required";
+        }
+        return null;         // Return `null` if it's valid, or an error message if it's invalid
+      },
+    },
+  });
+
+  return (
+    <>
+      <Modal opened={opened} onClose={onClose}
+        title="Duplicate Map" centered size="lg">
+        <form onSubmit={form.onSubmit((values) => console.log(values))}>
+          <Box>
+            <Stack justify="flex-start">
+              <TextInput
+                label="Map Name"
+                description="Enter a name to describe your map"
+                placeholder="Copy of Best places to eat in the East Blue"
+                style={{ width: "100%" }}
+                data-autofocus
+                withAsterisk
+                {...form.getInputProps("mapName")}
+              />
+              <Textarea
+                label="Map Description"
+                description="Enter a description to describe your new map"
+                placeholder="This is a map of the Grand Line"
+                style={{ width: "100%" }}
+                variant="filled"
+                data-autofocus
+                withAsterisk
+                {...form.getInputProps("description")}
+              />
+              <Select
+                label="Visibility"
+                placeholder="Public"
+                data={["Public", "Private"]}
+                style={{ width: "100%" }}
+                withAsterisk
+                {...form.getInputProps("visibility")}
+              />
+            </Stack>
+            <Stack style={{marginTop: "30px" }}>
+              <Button type="submit" onClick={onClose} style={{marginLeft: "auto" }}>
+                Submit
+              </Button>
+            </Stack>
+          </Box>
+        </form>
+      </Modal>
+    </>
+  );
+}
+
+export default DuplicateMapModal;

--- a/client/src/components/selectedcard/MapHeader.tsx
+++ b/client/src/components/selectedcard/MapHeader.tsx
@@ -1,15 +1,19 @@
 import "./css/mapHeader.css";
-import { Text, Group, Image, Avatar } from "@mantine/core";
-import pencil from "../../assets/images/pencil.png";
-import download from "../../assets/images/download.png";
-import duplicate from "../../assets/images/copy.png";
-import { useDisclosure } from '@mantine/hooks';
+import { useState } from "react";
+import { Link } from "react-router-dom";
 import DownloadMapModal from "../modals/DownloadMapModal"
+import DuplicateMapModal from "../modals/DuplicateMapModal";
+import DeleteMapModal from "../modals/DeleteMapModal";
+import { Text, Group, Avatar, Button } from "@mantine/core";
+import { IconEdit, IconDownload, IconCopy, IconTrash } from "@tabler/icons-react";
+
 const MapHeader = () => {
-  const [opened, { open, close }] = useDisclosure(false);
+  const [downloadModalOpen, setDownloadModalOpen] = useState(false);
+  const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
   return (
     <>
-    <DownloadMapModal opened={opened} onClose={close}></DownloadMapModal>
       <Text fw={500} size="sm" id="creationDate">
         Created 5 days ago
       </Text>
@@ -17,10 +21,20 @@ const MapHeader = () => {
         Best Places to Eat in The East Blue
       </Text>
       <Group id="edit">
-        <Image src={pencil} id="editIcon"></Image>
-        <Text size="xs" id="editText">
-          Edit Map
-        </Text>
+        <Link to="/edit" style={{ marginLeft: "auto" }}>
+          <Button
+            leftSection={<IconEdit size={14} />}
+            variant="subtle" color="gray"
+          >
+            Edit Map
+          </Button>
+        </Link>
+        <Button
+          leftSection={<IconTrash size={14} />}
+          variant="subtle" color="gray"
+          onClick={() => setDeleteModalOpen(true)}>
+          Delete
+        </Button>
       </Group>
 
       <Group>
@@ -35,17 +49,26 @@ const MapHeader = () => {
             </Text>
           </div>
         </Group>
+        <Group style={{ marginLeft: "auto" }}>
+          <Button
+            leftSection={<IconDownload size={14} />}
+            variant="subtle" color="gray"
+            onClick={() => setDownloadModalOpen(true)}>
+            Download
+          </Button>
 
-        <Image src={download} id="downloadIcon" onClick={open}></Image>
-        <Text size="xs" id="downloadText" onClick={open}>
-          Download
-        </Text>
-
-        <Image src={duplicate} id="duplicateIcon"></Image>
-        <Text size="xs" id="duplicateIcon">
-          Duplicate
-        </Text>
+          <Button
+            leftSection={<IconCopy size={14} />}
+            variant="subtle" color="gray"
+            onClick={() => setDuplicateModalOpen(true)}>
+            Duplicate
+          </Button>
+        </Group>
       </Group>
+      <DownloadMapModal opened={downloadModalOpen} onClose={() => setDownloadModalOpen(false)}></DownloadMapModal>
+      <DuplicateMapModal opened={duplicateModalOpen} onClose={() => setDuplicateModalOpen(false)}></DuplicateMapModal>
+      <DeleteMapModal opened={deleteModalOpen} onClose={() => setDeleteModalOpen(false)}></DeleteMapModal>
+
     </>
   );
 };


### PR DESCRIPTION
**Updates**
- Implemented routing to edit screen when edit button is seleted
- Added duplicate & delete map modal 

**Testing**
- [x] Pulled recent changes from main branch
- [x] Tested via `npm start`
- [ ] Ran `npm test`

**How to review:**
```
git checkout main
git fetch
git checkout selected_card_screen
cd client
npm start
```

1. Go to browser, click on card, see something like below: 
Updated Map Header with 4 buttons
<img width="1610" alt="image" src="https://github.com/JEMS-CSE416/JEMS/assets/53535722/103d43bd-8777-4833-a5b1-85ae22fa43db">

Duplicate Map Modal
<img width="1617" alt="image" src="https://github.com/JEMS-CSE416/JEMS/assets/53535722/07b638bf-fd25-4517-8970-b602e4a6ce7a">


Delete Map Modal
<img width="1617" alt="image" src="https://github.com/JEMS-CSE416/JEMS/assets/53535722/08b35b81-767c-44da-b7ce-927764b295ea">


