### PR TITLE
Add conditional rendering for CreateMapModal AKA Fixed modal not clearing data after submission or cancelation

### DIFF
--- a/client/src/components/common/Navbar.tsx
+++ b/client/src/components/common/Navbar.tsx
@@ -6,10 +6,18 @@ import { useDisclosure } from "@mantine/hooks";
 import CreateMapModal from "../modals/CreateMapModal";
 
 const NavBar = () => {
+  // the create modal state
   const [opened, { open, close }] = useDisclosure(false);
+
+
   return (
     <div id="navBar">
-      <CreateMapModal opened={opened} onClose={close}></CreateMapModal>
+
+      {/* show modal if opened */}
+      {opened && (
+        <CreateMapModal opened={opened} onClose={close}></CreateMapModal>
+      )}
+
       <Group>
         <Link to="/home">
           <Image src={jemsLogo} id="jemsLogo" />

--- a/client/src/components/modals/CreateMapModal.tsx
+++ b/client/src/components/modals/CreateMapModal.tsx
@@ -22,8 +22,8 @@ const CreateMapModal: React.FC<CreateMapModalProps> = ({ opened, onClose }) => {
   const form = useForm({
     initialValues: {
       creatorId: "652daf32e2225cdfeceea17f",
-      mapName: "map name",
-      description: "map des",
+      mapName: "",
+      description: "",
       creationDate: "2023-11-04T12:00:00Z",
       public: true,
       colorType: "basic",

--- a/client/src/components/modals/CreateMapModal.tsx
+++ b/client/src/components/modals/CreateMapModal.tsx
@@ -22,11 +22,11 @@ const CreateMapModal: React.FC<CreateMapModalProps> = ({ opened, onClose }) => {
   const form = useForm({
     initialValues: {
       creatorId: "652daf32e2225cdfeceea17f",
-      mapName: "enter a map name",
-      description: "enter a description",
+      mapName: "",
+      description: "",
       creationDate: "2023-11-04T12:00:00Z",
       public: true,
-      colorType: "basic",
+      colorType: "",
       displayStrings: true,
       displayNumerics: true,
       displayLegend: true,

--- a/client/src/components/modals/CreateMapModal.tsx
+++ b/client/src/components/modals/CreateMapModal.tsx
@@ -18,11 +18,12 @@ interface CreateMapModalProps {
 }
 
 const CreateMapModal: React.FC<CreateMapModalProps> = ({ opened, onClose }) => {
+  // Form state that we'll use as default values for now
   const form = useForm({
     initialValues: {
       creatorId: "652daf32e2225cdfeceea17f",
-      mapName: "hello",
-      description: "hi",
+      mapName: "enter a map name",
+      description: "enter a description",
       creationDate: "2023-11-04T12:00:00Z",
       public: true,
       colorType: "basic",
@@ -84,6 +85,7 @@ const CreateMapModal: React.FC<CreateMapModalProps> = ({ opened, onClose }) => {
     },
   });
 
+  // Handle form submission and close the modal
   const handleFormSubmit = async () => {
     console.log("Form values:", form.values);
     const req = {
@@ -131,6 +133,8 @@ const CreateMapModal: React.FC<CreateMapModalProps> = ({ opened, onClose }) => {
     } catch (error) {
       console.error("Error updating data:", error);
     }
+
+    onClose();
   };
 
   return (
@@ -197,9 +201,7 @@ const CreateMapModal: React.FC<CreateMapModalProps> = ({ opened, onClose }) => {
             </Group>
 
             <Group justify="flex-end" mt="md">
-              <Button type="submit" onClick={onClose}>
-                Submit
-              </Button>
+              <Button type="submit">Submit</Button>
             </Group>
           </form>
         </Box>

--- a/client/src/components/modals/DuplicateMapModal.tsx
+++ b/client/src/components/modals/DuplicateMapModal.tsx
@@ -46,7 +46,7 @@ const DuplicateMapModal: React.FC<DuplicateMapModalProps> = ({ opened, onClose }
     <>
       <Modal opened={opened} onClose={onClose}
         title="Duplicate Map" centered size="lg">
-        <form onSubmit={form.onSubmit((values) => console.log(values))}>
+        <form onSubmit={form.onSubmit((values) => handleMakeCopy())}>
           <Box>
             <Stack justify="flex-start">
               <TextInput
@@ -78,7 +78,7 @@ const DuplicateMapModal: React.FC<DuplicateMapModalProps> = ({ opened, onClose }
               />
             </Stack>
             <Stack style={{marginTop: "30px" }}>
-              <Button type="submit" onClick={handleMakeCopy} style={{marginLeft: "auto" }}>
+              <Button type="submit"  style={{marginLeft: "auto" }}>
                 Make copy
               </Button>
             </Stack>

--- a/client/src/components/selectedcard/MapHeader.tsx
+++ b/client/src/components/selectedcard/MapHeader.tsx
@@ -1,19 +1,51 @@
 import "./css/mapHeader.css";
-import { useState } from "react";
 import { Link } from "react-router-dom";
-import DownloadMapModal from "../modals/DownloadMapModal"
+import DownloadMapModal from "../modals/DownloadMapModal";
 import DuplicateMapModal from "../modals/DuplicateMapModal";
 import DeleteMapModal from "../modals/DeleteMapModal";
 import { Text, Group, Avatar, Button } from "@mantine/core";
-import { IconEdit, IconDownload, IconCopy, IconTrash } from "@tabler/icons-react";
+import {
+  IconEdit,
+  IconDownload,
+  IconCopy,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useDisclosure } from "@mantine/hooks";
 
 const MapHeader = () => {
-  const [downloadModalOpen, setDownloadModalOpen] = useState(false);
-  const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  // the download modal state
+  const [downloadModalOpened, setDownloadModal] = useDisclosure(false);
+  // the duplicate modal state
+  const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
+  // the delete modal state
+  const [deleteModalOpened, setDeleteModal] = useDisclosure(false);
 
   return (
     <>
+      {/* Show download modal when needed */}
+      {downloadModalOpened && (
+        <DownloadMapModal
+          opened={downloadModalOpened}
+          onClose={setDownloadModal.close}
+        />
+      )}
+
+      {/* Show duplicate modal when needed */}
+      {duplicateModalOpened && (
+        <DuplicateMapModal
+          opened={duplicateModalOpened}
+          onClose={setDuplicateModal.close}
+        />
+      )}
+
+      {/* Show delete modal when needed */}
+      {deleteModalOpened && (
+        <DeleteMapModal
+          opened={deleteModalOpened}
+          onClose={setDeleteModal.close}
+        ></DeleteMapModal>
+      )}
+
       <Text fw={500} size="sm" id="creationDate">
         Created 5 days ago
       </Text>
@@ -24,22 +56,27 @@ const MapHeader = () => {
         <Link to="/edit" style={{ marginLeft: "auto" }}>
           <Button
             leftSection={<IconEdit size={14} />}
-            variant="subtle" color="gray"
+            variant="subtle"
+            color="gray"
           >
             Edit Map
           </Button>
         </Link>
         <Button
           leftSection={<IconTrash size={14} />}
-          variant="subtle" color="gray"
-          onClick={() => setDeleteModalOpen(true)}>
+          variant="subtle"
+          color="gray"
+          onClick={setDeleteModal.open}
+        >
           Delete
         </Button>
       </Group>
 
       <Group>
         <Group>
-          <Avatar color="blue" radius="xl">L</Avatar>
+          <Avatar color="blue" radius="xl">
+            L
+          </Avatar>
           <div>
             <Text fw={500} size="sm" id="creatorName">
               @Luffy
@@ -52,23 +89,23 @@ const MapHeader = () => {
         <Group style={{ marginLeft: "auto" }}>
           <Button
             leftSection={<IconDownload size={14} />}
-            variant="subtle" color="gray"
-            onClick={() => setDownloadModalOpen(true)}>
+            variant="subtle"
+            color="gray"
+            onClick={setDownloadModal.open}
+          >
             Download
           </Button>
 
           <Button
             leftSection={<IconCopy size={14} />}
-            variant="subtle" color="gray"
-            onClick={() => setDuplicateModalOpen(true)}>
+            variant="subtle"
+            color="gray"
+            onClick={setDuplicateModal.open}
+          >
             Duplicate
           </Button>
         </Group>
       </Group>
-      <DownloadMapModal opened={downloadModalOpen} onClose={() => setDownloadModalOpen(false)}></DownloadMapModal>
-      <DuplicateMapModal opened={duplicateModalOpen} onClose={() => setDuplicateModalOpen(false)}></DuplicateMapModal>
-      <DeleteMapModal opened={deleteModalOpen} onClose={() => setDeleteModalOpen(false)}></DeleteMapModal>
-
     </>
   );
 };


### PR DESCRIPTION
**Updates**
- Fixed bug where modal does not reset create map form field values after submission or cancellation.
- also bundled in where modal for duplicate map form field values are not reset after submission or cancellation.
- 
**How to review:**
```
git checkout main
git fetch
git checkout clearmapcreatemodal
cd client
npm start
```

1. Go to main page and create a map by filling out the form.
2. either cancel the creation or confirm the creation. either way the form will reset upon cancelation or submission.


**IMPORTANT PLEASE READ:**
when adding a modal to any component. (eg: CreateMapModal)
` <CreateMapModal />`

Please make sure to use the useDisclosure hook 
```
import { useDisclosure } from "@mantine/hooks";
const [createMapModalOpened, setCreateMapModal] = useDisclosure(false);
```

the reason for this is because useDisclosure has a really Nice way of using boolean states.
rather than creating a state and toggling back and forth between the `true` and `false` states, you can simply call a function that semantically equal to what you want.

` <Button radius="xl" onClick={setCreateMapModal.open}>Click me to open a modal!</Button>`
The code above opens the modal.

` <Button radius="xl" onClick={setCreateMapModal.close}>click me to close a modal</Button>`
The code above will close a modal.

Finally, when adding a modal to a component, please use conditional loading. This effectively resets the contents of the modal as once the modal closes it dismounts.
```
  {ModalOpened && (
    <Modal opened={createMapModalOpened} onClose={setCreateMapModal.close}></CreateMapModal>
  )}
```
