### PR TITLE
added edit, duplicate & delete cypress tests

### DIFF
--- a/client/cypress/e2e/jems/id.js
+++ b/client/cypress/e2e/jems/id.js
@@ -2,13 +2,15 @@
 
 const splashGetStartedButton = '#' + 'splash-button';
 const mapCard = '#card';
-const loginButton = '#loginButton'
+const loginButton = '#loginButton';
+const editButton = '#edit-button';
 
 context('Share IDs across all suites', () => {
     // Generating a random userCount value for further verifications.
     module.exports = {
         splashGetStartedButton,
         mapCard,
-        loginButton
+        loginButton,
+        editButton,
     }
 });

--- a/client/cypress/e2e/jems/routing.cy.js
+++ b/client/cypress/e2e/jems/routing.cy.js
@@ -1,22 +1,31 @@
 /// <reference types="cypress" />
 
-import { splashGetStartedButton, mapCard, loginButton } from "./id";
+import {
+  splashGetStartedButton,
+  mapCard,
+  loginButton,
+  editButton,
+} from "./id";
 
 beforeEach(() => {
-    cy.visit('/');
+  cy.visit("/");
 });
 
-describe('Routing', () => {
-    it('Navigates to home and selected pages', () => {
-        cy.get(splashGetStartedButton).click();
-        cy.get(loginButton).click();
-        cy.url().should('include', '/home');
+describe("Routing", () => {
+  it("Navigates to home and selected pages", () => {
+    cy.get(splashGetStartedButton).click();
+    cy.get(loginButton).click();
+    cy.url().should("include", "/home");
 
-        cy.get(mapCard).click();
-        cy.url().should('include', '/selected');
-    });
+    cy.get(mapCard).click();
+    cy.url().should("include", "/selected");
+
+    cy.get(editButton).click();
+    cy.url().should("include", "/edit");
+
+  });
 });
 
-describe('Modal checking', () => {
-    
-})
+describe("Modal checking", () => {
+
+});

--- a/client/cypress/e2e/jems/selectedCard.cy.js
+++ b/client/cypress/e2e/jems/selectedCard.cy.js
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+
+const duplicateButton = '#duplicate-button';
+const duplicateModal = '#duplicate-modal';
+const duplicateModalSubmitButton = '#duplicate-modal-submit-button';
+
+const deleteButton = "#delete-button";
+const downloadButton = "#download-button";
+const deleteModalConfirmButton = "#delete-modal-confirm-button";
+const deleteModalCancelButton = "#delete-modal-cancel-button";
+
+beforeEach(() => {
+  cy.visit("/selected");
+});
+
+describe("Modal checking", () => {
+  it("Checks if the duplicate modal is visible", () => {
+    // Click on the button to open the duplicate modal
+    cy.get(duplicateButton).click();
+    cy.get(duplicateModalSubmitButton).click();
+  });
+  it("Checks if the delete modal is visible", () => {
+    // Click on the button to open the delete modal
+    cy.get(deleteButton).click();
+    cy.get(deleteModalConfirmButton).click();
+  });
+});

--- a/client/src/components/modals/CreateMapModal.tsx
+++ b/client/src/components/modals/CreateMapModal.tsx
@@ -138,12 +138,9 @@ const CreateMapModal: React.FC<CreateMapModalProps> = ({ opened, onClose }) => {
 
   return (
     <>
-      <Modal
-        opened={opened}
-        onClose={onClose}
-        title="Create Map"
-        centered
-        size="70%"
+      <Modal id="delete-modal" opened={opened}
+        onClose={onClose} title="Create Map"
+        centered size="70%"
       >
         <Box style={{ margin: "20px" }}>
           <form onSubmit={form.onSubmit((values) => handleFormSubmit())}>

--- a/client/src/components/modals/DeleteMapModal.tsx
+++ b/client/src/components/modals/DeleteMapModal.tsx
@@ -20,12 +20,12 @@ const DeleteMapModal: React.FC<DeleteMapModalProps> = ({ opened, onClose }) => {
 
   return (
     <>
-      <Modal opened={opened} onClose={onClose} title="Delete Map?" centered size="auto">
+      <Modal id="delete-modal" opened={opened} onClose={onClose} title="Delete Map?" centered size="auto">
         <Group justify="space-between">
-          <Button variant="light" onClick={onClose}>
+          <Button variant="light" onClick={onClose} id="delete-modal-cancel-button">
             Cancel
           </Button>
-          <Button variant="filled" onClick={handleConfirm}>
+          <Button variant="filled" onClick={handleConfirm} id="delete-modal-confirm-button">
             Confirm
           </Button>
         </Group>

--- a/client/src/components/modals/DownloadMapModal.tsx
+++ b/client/src/components/modals/DownloadMapModal.tsx
@@ -10,7 +10,7 @@ interface DownloadMapModalProps {
 const DownloadMapModal: React.FC<DownloadMapModalProps> =({opened, onClose}) => {
   return (
     <>
-      <Modal opened={opened} onClose={onClose} title="Save As" centered>
+      <Modal id="download-modal" opened={opened} onClose={onClose} title="Save As" centered>
         <Group justify="space-between">
           <Button variant="light" id="saveAsButton">PNG</Button>
           <Button variant="light" id="saveAsButton">JPG</Button>

--- a/client/src/components/modals/DuplicateMapModal.tsx
+++ b/client/src/components/modals/DuplicateMapModal.tsx
@@ -78,7 +78,7 @@ const DuplicateMapModal: React.FC<DuplicateMapModalProps> = ({ opened, onClose }
               />
             </Stack>
             <Stack style={{marginTop: "30px" }}>
-              <Button type="submit"  style={{marginLeft: "auto" }}>
+              <Button id="duplicate-modal-submit-button" type="submit" style={{marginLeft: "auto" }}>
                 Make copy
               </Button>
             </Stack>

--- a/client/src/components/selectedcard/MapHeader.tsx
+++ b/client/src/components/selectedcard/MapHeader.tsx
@@ -58,6 +58,7 @@ const MapHeader = () => {
             leftSection={<IconEdit size={14} />}
             variant="subtle"
             color="gray"
+            id="edit-button"
           >
             Edit Map
           </Button>
@@ -67,6 +68,7 @@ const MapHeader = () => {
           variant="subtle"
           color="gray"
           onClick={setDeleteModal.open}
+          id="delete-button"
         >
           Delete
         </Button>
@@ -92,6 +94,7 @@ const MapHeader = () => {
             variant="subtle"
             color="gray"
             onClick={setDownloadModal.open}
+            id="download-button"
           >
             Download
           </Button>
@@ -101,6 +104,7 @@ const MapHeader = () => {
             variant="subtle"
             color="gray"
             onClick={setDuplicateModal.open}
+            id="duplicate-button"
           >
             Duplicate
           </Button>


### PR DESCRIPTION
**Updates**
- Implemented cypress front ends test for routing & selected card screen. Clicking on edit button on selected card screen should bring the page to the edit screen. Clicking duplicate& delete buttons should open modals respectively.  

**Testing**
- [x] Pulled recent changes from main branch

**How to review:**
```
git checkout main
git fetch
git checkout selected_card_cypress
npx cypress open
e2e testing
click on selected_card
should pass
```