### PR TITLE
Duplicate map modal

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
         "@types/shapefile": "^0.6.1",
+        "date-fns": "^2.30.0",
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
@@ -7484,6 +7485,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dayjs": {

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@types/shapefile": "^0.6.1",
+    "date-fns": "^2.30.0",
     "geojson": "^0.5.0",
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",

--- a/client/src/api/MapApiAccessor.ts
+++ b/client/src/api/MapApiAccessor.ts
@@ -7,7 +7,7 @@ const mapsUrl = BACKEND_URL + "/api/maps/"
 export async function getMap(id: string): Promise<Map> {
   // TODO: replace this with an actual getMap endpoint
   console.log("TODO: REMOVE PLACEHOLDER IN GETMAP", id);
-  return Promise.resolve(ErrorMap);
+  return Promise.reject("Error fetching map");
 }
 
 interface MapQueryParams {

--- a/client/src/components/browsing/Discover.tsx
+++ b/client/src/components/browsing/Discover.tsx
@@ -4,12 +4,45 @@ import { Link } from "react-router-dom";
 import MapCard from "./MapCard";
 import NavBar from "../common/Navbar";
 import Footer from "../common/Footer";
+import { Map } from "../../utils/models/Map";
+import { getMaps } from "../../api/MapApiAccessor";
+import { useEffect, useState } from "react";
+import { useDisclosure } from "@mantine/hooks";
+import DuplicateMapModal from "../modals/DuplicateMapModal";
 
 const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
 
 function Discover() {
+  useEffect(() => {
+    getPublicMaps();
+  }, []);
+  const [selectedMapToDuplicate, setSelectedMapToDuplicate] = useState<Map>();
+  const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
+  const [maps, setMaps] = useState<Map[]>([]);
+
+  const getPublicMaps = async () => {
+    try {
+      const responseData = await getMaps({ isPrivate: false });
+      console.log("Public Maps fetched successfully:", responseData);
+      setMaps(responseData);
+    } catch (error) {
+      console.error("Error updating data:", error);
+    }
+  };
+
+  const handleSelectMapToDuplicate = (map: Map) => {
+    console.log("Selected map to duplicate:", map);
+    setSelectedMapToDuplicate(map);
+    setDuplicateModal.open();
+  };
+
   return (
     <>
+      <DuplicateMapModal
+        opened={duplicateModalOpened}
+        onClose={setDuplicateModal.close}
+        map={selectedMapToDuplicate}
+      />
       <NavBar />
       <div id="content">
         <Stack>
@@ -27,47 +60,19 @@ function Discover() {
                 </Text>
               </Group>
               <Grid style={{ textAlign: "initial" }}>
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
+                {maps.map((map) => (
+                  <Grid.Col span={cardSpan}>
+                    <MapCard
+                      isPrivate={!map.public}
+                      name={map["mapName"]}
+                      description={map.description}
+                      map={map}
+                      duplicateAction={() => {
+                        handleSelectMapToDuplicate(map);
+                      }}
+                    />
+                  </Grid.Col>
+                ))}
               </Grid>
             </Stack>
           </Box>

--- a/client/src/components/browsing/HomeScreen.tsx
+++ b/client/src/components/browsing/HomeScreen.tsx
@@ -8,10 +8,14 @@ import { useState } from "react";
 import { useEffect } from "react";
 import { getMaps } from "../../api/MapApiAccessor";
 import { Map } from "../../utils/models/Map";
+import { useDisclosure } from "@mantine/hooks";
+import DuplicateMapModal from "../modals/DuplicateMapModal";
 
 const HomePage = () => {
   const [maps, setMaps] = useState<Map[]>([]);
   const [yourMaps, setYourMaps] = useState<Map[]>([]);
+
+  const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
 
   useEffect(() => {
     getPublicMaps();
@@ -22,7 +26,7 @@ const HomePage = () => {
     try {
       const responseData = await getMaps({ isPrivate: false });
       console.log("Public Maps fetched successfully:", responseData);
-      setMaps(responseData);
+      setMaps(responseData.splice(0, 6));
     } catch (error) {
       console.error("Error updating data:", error);
     }
@@ -35,16 +39,21 @@ const HomePage = () => {
         creatorId: "652daf32e2225cdfeceea14f",
       });
       console.log("Your Maps fetched successfully:", responseData);
-      setYourMaps(responseData);
+      setYourMaps(responseData.splice(0, 6));
     } catch (error) {
       console.error("Error updating data:", error);
     }
   };
 
+
   const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
 
   return (
     <>
+      <DuplicateMapModal
+        opened={duplicateModalOpened}
+        onClose={setDuplicateModal.close}
+      />
       <NavBar></NavBar>
       <div id="content">
         <Stack>
@@ -67,10 +76,16 @@ const HomePage = () => {
                 </Link>
               </Group>
               <Grid style={{ textAlign: "initial" }}>
-                {yourMaps.map((map,i) => (
+                {yourMaps.map((map, i) => (
                   <Grid.Col span={cardSpan}>
                     <Link to="/selected">
-                      <MapCard id={`MyMapCard${i+1}`} name={map.mapName} description={map.description} isPrivate={!map.public} map={map} />
+                      <MapCard
+                        id={`MyMapCard${i + 1}`}
+                        name={map.mapName}
+                        description={map.description}
+                        isPrivate={!map.public}
+                        map={map}
+                      />
                     </Link>
                   </Grid.Col>
                 ))}
@@ -104,6 +119,7 @@ const HomePage = () => {
                       name={map["mapName"]}
                       description={map.description}
                       map={map}
+                      duplicateModalTrigger={setDuplicateModal}
                     />
                   </Grid.Col>
                 ))}

--- a/client/src/components/browsing/HomeScreen.tsx
+++ b/client/src/components/browsing/HomeScreen.tsx
@@ -14,7 +14,7 @@ import DuplicateMapModal from "../modals/DuplicateMapModal";
 const HomePage = () => {
   const [maps, setMaps] = useState<Map[]>([]);
   const [yourMaps, setYourMaps] = useState<Map[]>([]);
-
+  const [selectedMapToDuplicate, setSelectedMapToDuplicate] = useState<Map>();
   const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
 
   useEffect(() => {
@@ -26,7 +26,7 @@ const HomePage = () => {
     try {
       const responseData = await getMaps({ isPrivate: false });
       console.log("Public Maps fetched successfully:", responseData);
-      setMaps(responseData.splice(0, 6));
+      setMaps(responseData.splice(0, 8));
     } catch (error) {
       console.error("Error updating data:", error);
     }
@@ -39,11 +39,17 @@ const HomePage = () => {
         creatorId: "652daf32e2225cdfeceea14f",
       });
       console.log("Your Maps fetched successfully:", responseData);
-      setYourMaps(responseData.splice(0, 6));
+      setYourMaps(responseData.splice(0, 8));
     } catch (error) {
       console.error("Error updating data:", error);
     }
   };
+
+  const handleSelectMapToDuplicate = (map:Map) => {
+    console.log("Selected map to duplicate:", map);
+    setSelectedMapToDuplicate(map);
+    setDuplicateModal.open();
+  }
 
 
   const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
@@ -53,6 +59,7 @@ const HomePage = () => {
       <DuplicateMapModal
         opened={duplicateModalOpened}
         onClose={setDuplicateModal.close}
+        map={selectedMapToDuplicate}
       />
       <NavBar></NavBar>
       <div id="content">
@@ -85,6 +92,7 @@ const HomePage = () => {
                         description={map.description}
                         isPrivate={!map.public}
                         map={map}
+                        duplicateAction={() => {handleSelectMapToDuplicate(map)}}
                       />
                     </Link>
                   </Grid.Col>
@@ -119,7 +127,7 @@ const HomePage = () => {
                       name={map["mapName"]}
                       description={map.description}
                       map={map}
-                      duplicateModalTrigger={setDuplicateModal}
+                      duplicateAction={() => {handleSelectMapToDuplicate(map)}}
                     />
                   </Grid.Col>
                 ))}

--- a/client/src/components/browsing/MapCard.tsx
+++ b/client/src/components/browsing/MapCard.tsx
@@ -12,11 +12,7 @@ type MapCardProps = {
   isPrivate?: boolean;
   id?: string;
   map?: Map;
-  duplicateModalTrigger?: {
-    readonly open: () => void;
-    readonly close: () => void;
-    readonly toggle: () => void;
-  };
+  duplicateAction?: () => void;
   downloadAs?: (format: "PNG" | "JPEG" | "JEMS") => void;
 };
 
@@ -26,12 +22,11 @@ const MapCard: React.FC<MapCardProps> = ({
   isPrivate,
   id,
   map,
-  duplicateModalTrigger,
+  duplicateAction,
   downloadAs,
 }) => {
-
   const navigate = useNavigate();
-  
+
   // splices the createdAt string to show how long ago was it made.
   // for example: 2023-10-16T21:46:26.858+00:00 -> Created 5 minutes ago
   function formatDate(dateString: string): string {
@@ -60,7 +55,7 @@ const MapCard: React.FC<MapCardProps> = ({
         {name}
       </Text>
       <Text size="9px" ta="left">
-        Luffy • {formatDate(map?.creationDate.toISOString() ?? "")}
+        Luffy • {formatDate(map?.creationDate ?? "")}
       </Text>
       <Text size="10px" ta="left" id="mapDescription" lineClamp={4}>
         {description}
@@ -85,11 +80,18 @@ const MapCard: React.FC<MapCardProps> = ({
             offset={4}
           >
             <Menu.Target>
-              <IconDots
-                height={20}
-                color="black"
-                style={{ cursor: "pointer" }}
-              />
+              <Button variant="subtle" size="compact-xs" onClick={
+                (e)=> {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }
+                }>
+                <IconDots
+                  height={20}
+                  color="black"
+                  style={{ cursor: "pointer" }}
+                />
+              </Button>
             </Menu.Target>
             <Menu.Dropdown>
               {/* <Menu.Label>Application</Menu.Label> */}
@@ -120,7 +122,7 @@ const MapCard: React.FC<MapCardProps> = ({
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
-                  duplicateModalTrigger?.open();
+                  duplicateAction?.();
                 }}
               >
                 Duplicate

--- a/client/src/components/browsing/MapCard.tsx
+++ b/client/src/components/browsing/MapCard.tsx
@@ -1,8 +1,10 @@
 import { Card, Image, Text, Badge, Group, Button, Menu } from "@mantine/core";
 import "./css/mapCard.css";
 import React from "react";
+import { formatDistanceToNow } from "date-fns";
 import { IconDots } from "@tabler/icons-react";
 import { Map } from "../../utils/models/Map";
+import { useNavigate } from "react-router-dom";
 
 type MapCardProps = {
   name?: string;
@@ -10,6 +12,12 @@ type MapCardProps = {
   isPrivate?: boolean;
   id?: string;
   map?: Map;
+  duplicateModalTrigger?: {
+    readonly open: () => void;
+    readonly close: () => void;
+    readonly toggle: () => void;
+  };
+  downloadAs?: (format: "PNG" | "JPEG" | "JEMS") => void;
 };
 
 const MapCard: React.FC<MapCardProps> = ({
@@ -18,7 +26,19 @@ const MapCard: React.FC<MapCardProps> = ({
   isPrivate,
   id,
   map,
+  duplicateModalTrigger,
+  downloadAs,
 }) => {
+
+  const navigate = useNavigate();
+  
+  // splices the createdAt string to show how long ago was it made.
+  // for example: 2023-10-16T21:46:26.858+00:00 -> Created 5 minutes ago
+  function formatDate(dateString: string): string {
+    const date = new Date(dateString);
+    const formattedDate = formatDistanceToNow(date, { addSuffix: true });
+    return `Created ${formattedDate}`;
+  }
 
   return (
     <Card
@@ -40,7 +60,7 @@ const MapCard: React.FC<MapCardProps> = ({
         {name}
       </Text>
       <Text size="9px" ta="left">
-        Luffy • Created 5 minutes ago
+        Luffy • {formatDate(map?.creationDate.toISOString() ?? "")}
       </Text>
       <Text size="10px" ta="left" id="mapDescription" lineClamp={4}>
         {description}
@@ -65,21 +85,18 @@ const MapCard: React.FC<MapCardProps> = ({
             offset={4}
           >
             <Menu.Target>
-              <Button
-                variant="subtle"
-                size="compact-xs"
-                onClick={(e) => {
-                  e.preventDefault();
-                }}
-              >
-                <IconDots height={20} color="black"></IconDots>
-              </Button>
+              <IconDots
+                height={20}
+                color="black"
+                style={{ cursor: "pointer" }}
+              />
             </Menu.Target>
             <Menu.Dropdown>
               {/* <Menu.Label>Application</Menu.Label> */}
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  downloadAs?.("PNG");
                 }}
               >
                 Download as PNG
@@ -87,6 +104,7 @@ const MapCard: React.FC<MapCardProps> = ({
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  downloadAs?.("JPEG");
                 }}
               >
                 Download as JPG
@@ -94,13 +112,15 @@ const MapCard: React.FC<MapCardProps> = ({
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  downloadAs?.("JEMS");
                 }}
               >
-                Download as JSON
+                Download as JEMS
               </Menu.Item>
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  duplicateModalTrigger?.open();
                 }}
               >
                 Duplicate

--- a/client/src/components/browsing/MapCard.tsx
+++ b/client/src/components/browsing/MapCard.tsx
@@ -55,7 +55,7 @@ const MapCard: React.FC<MapCardProps> = ({
         {name}
       </Text>
       <Text size="9px" ta="left">
-        Luffy • {formatDate(map?.creationDate ?? "")}
+        Luffy • {formatDate(map?.creationDate ?? "2023-11-20T02:57:13.344+00:00")}
       </Text>
       <Text size="10px" ta="left" id="mapDescription" lineClamp={4}>
         {description}

--- a/client/src/components/modals/DuplicateMapModal.tsx
+++ b/client/src/components/modals/DuplicateMapModal.tsx
@@ -11,16 +11,19 @@ import React from "react";
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
 import { IconCheck } from "@tabler/icons-react";
+import { Map } from "../../utils/models/Map";
 
 interface DuplicateMapModalProps {
   opened: boolean;
   onClose: () => void;
+  map?: Map;
 }
 
 // The base duplicate map modal with all the logic
 const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
   opened,
   onClose,
+  map,
 }) => {
   const form = useForm({
     initialValues: {
@@ -45,7 +48,40 @@ const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
     },
   });
 
-  const handleMakeCopy = () => {
+  const handleMakeCopy = async () => {
+    // console.log("Form values:", form.values);
+    // console.log("Map to duplicate:", map);
+    /*
+    REPLACE THIS LOGIC WITH API ACCESSOR FOR DUPLICATION
+    */
+    try {
+      const data = {
+        map_id: map?._id,
+        map_name: form.values.mapName,
+        description: form.values.description,
+        public: (form.values.visibility == "Public" ? true : false),
+      };
+
+      // Replace with your API endpoint
+      const response = await fetch(
+        "https://dev-jems-api.miguelmaramara.com/api/maps/duplicate",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer 652daf32e2225cdfeceea14f", // TODO: replace with actual session token
+          },
+          body: JSON.stringify(data),
+        }
+      );
+    } catch (error) {
+      console.error("Error duplicating map:", error);
+    }
+
+    /*
+    REPLACE THIS LOGIC WITH API ACCESSOR FOR DUPLICATION
+    */
+
     onClose();
     notifications.show({
       icon: <IconCheck />,
@@ -114,9 +150,14 @@ const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
 const DuplicateMapModal: React.FC<DuplicateMapModalProps> = ({
   opened,
   onClose,
+  map,
 }) => {
   return (
-    <>{opened && <DuplicateMapModalBase opened={opened} onClose={onClose} />}</>
+    <>
+      {opened && (
+        <DuplicateMapModalBase opened={opened} onClose={onClose} map={map} />
+      )}
+    </>
   );
 };
 

--- a/client/src/utils/models/Map.ts
+++ b/client/src/utils/models/Map.ts
@@ -20,19 +20,20 @@ export interface Region {
 }
 
 export interface Map {
-  creatorId: string;
-  mapName: string;
-  description: string;
-  public: boolean;
-  colorType: string;
-  displayStrings: boolean;
-  displayNumerics: boolean;
-  displayLegend: boolean;
-  displayPointers: boolean;
-  thumbnail: Image;
-  regions: { [key: string]: Region[] };
-  legend: Legend;
-}
+    creatorId: string;
+    mapName: string;
+    description: string;
+    creationDate: Date;
+    public: boolean;
+    colorType: string;
+    displayStrings: boolean;
+    displayNumerics: boolean;
+    displayLegend: boolean;
+    displayPointers: boolean;
+    thumbnail: Image;
+    regions: { [key: string]: Region[] };
+    legend: Legend;
+  }
 
 export const ErrorMap = {
     "creatorId": "652daf32e2225cdfeceea17f",

--- a/client/src/utils/models/Map.ts
+++ b/client/src/utils/models/Map.ts
@@ -20,10 +20,11 @@ export interface Region {
 }
 
 export interface Map {
+    _id: string;
     creatorId: string;
     mapName: string;
     description: string;
-    creationDate: Date;
+    creationDate: string;
     public: boolean;
     colorType: string;
     displayStrings: boolean;
@@ -36,8 +37,10 @@ export interface Map {
   }
 
 export const ErrorMap = {
+    "_id": "ERROR/TEST Map",
     "creatorId": "652daf32e2225cdfeceea17f",
     "mapName": "ERROR/TEST Map",
+    "creationDate": "2021-04-01T00:00:00.000Z",
     "description": "This map is a testing map. See either in an error or in a testing/hard-coded version of code.",
     "public": true,
     "colorType": "Color",


### PR DESCRIPTION
**Updates**
- Implemented duplicate map modal.
- implemented card creation date in map card.
- implemented displaying 8 maps total for Home Screen
- fixed static card displaying on discover maps page.

**How to review:**
```
git checkout main
git fetch
git checkout duplicateMapModal
cd client
npm start
```

1. Go to browser & try to duplicate any of the maps via the 3 dots.