### PR TITLE
Pagination

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
         <Routes>
           <Route path="/" element={<SplashScreen />} />
           <Route path="/home" element={<HomeScreen />} />
-          <Route path="/selected" element={<SelectedCardPage />} />
+          <Route path="/map/:id" element={<SelectedCardPage />} />
           <Route path="/myMaps" element={<MyMaps />} />
           <Route path="/discover" element={<Discover />} />
           <Route path="/edit/:id?" element={<Edit />} />

--- a/client/src/api/MapApiAccessor.ts
+++ b/client/src/api/MapApiAccessor.ts
@@ -90,6 +90,7 @@ export async function duplicateMap({
   creatorId,
 }: duplicateMapParams) {
   try {
+    console.log("DUPLICATE MAPPP: ", mapId, mapName, description, isPublic, creatorId)
     // TODO: replace with mapsurl when live server is up
     const res = await fetch(mapsUrl + "duplicate/", {
       method: "POST",
@@ -104,8 +105,7 @@ export async function duplicateMap({
         public: isPublic,
       }),
     });
-    console.log(res);
   } catch (error) {
-    console.error("Error updating data:", error);
+    console.error("Error Duplicating Map:", error);
   }
 }

--- a/client/src/components/browsing/Discover.tsx
+++ b/client/src/components/browsing/Discover.tsx
@@ -1,6 +1,6 @@
 import "./css/myMaps.css";
 import { Text, Pagination, Stack, Box, Group, Grid } from "@mantine/core";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import MapCard from "./MapCard";
 import NavBar from "../common/Navbar";
 import Footer from "../common/Footer";
@@ -16,7 +16,9 @@ function Discover() {
   useEffect(() => {
     getPublicMaps();
   }, []);
-  const [selectedMapToDuplicate, setSelectedMapToDuplicate] = useState<Map>();
+
+  const location = useLocation();
+
   const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
   const [maps, setMaps] = useState<Map[]>([]);
 
@@ -32,7 +34,7 @@ function Discover() {
 
   const handleSelectMapToDuplicate = (map: Map) => {
     console.log("Selected map to duplicate:", map);
-    setSelectedMapToDuplicate(map);
+    location.state = map;
     setDuplicateModal.open();
   };
 
@@ -41,7 +43,6 @@ function Discover() {
       <DuplicateMapModal
         opened={duplicateModalOpened}
         onClose={setDuplicateModal.close}
-        map={selectedMapToDuplicate}
       />
       <NavBar />
       <div id="content">

--- a/client/src/components/browsing/Discover.tsx
+++ b/client/src/components/browsing/Discover.tsx
@@ -1,5 +1,14 @@
 import "./css/myMaps.css";
-import { Text, Pagination, Stack, Box, Group, Grid } from "@mantine/core";
+import {
+  Text,
+  Pagination,
+  Stack,
+  Box,
+  Group,
+  Grid,
+  Loader,
+  Container,
+} from "@mantine/core";
 import { Link, useLocation } from "react-router-dom";
 import MapCard from "./MapCard";
 import NavBar from "../common/Navbar";
@@ -9,34 +18,28 @@ import { getMaps } from "../../api/MapApiAccessor";
 import { useEffect, useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import DuplicateMapModal from "../modals/DuplicateMapModal";
+import { useLoadingData } from "../hooks/useLoadingData";
 
 const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
 
 function Discover() {
-  useEffect(() => {
-    getPublicMaps();
-  }, []);
-
   const location = useLocation();
-
   const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
-  const [maps, setMaps] = useState<Map[]>([]);
-
-  const getPublicMaps = async () => {
-    try {
-      const responseData = await getMaps({ isPrivate: false });
-      console.log("Public Maps fetched successfully:", responseData);
-      setMaps(responseData);
-    } catch (error) {
-      console.error("Error updating data:", error);
-    }
-  };
+  const {data:maps, error, loading} = useLoadingData<Map[]>(getMaps, [{ isPrivate: false }]);
+  const [page, setPage] = useState(1);
+  const [pageTotal, setPageTotal] = useState(8);
 
   const handleSelectMapToDuplicate = (map: Map) => {
     console.log("Selected map to duplicate:", map);
     location.state = map;
     setDuplicateModal.open();
   };
+
+  // starting card index
+  const start = (page - 1) * pageTotal;
+
+  // ending card index
+  const end = page * pageTotal;
 
   return (
     <>
@@ -45,6 +48,7 @@ function Discover() {
         onClose={setDuplicateModal.close}
       />
       <NavBar />
+
       <div id="content">
         <Stack>
           <Box>
@@ -61,25 +65,39 @@ function Discover() {
                 </Text>
               </Group>
               <Grid style={{ textAlign: "initial" }}>
-                {maps.map((map) => (
-                  <Grid.Col span={cardSpan}>
-                    <MapCard
-                      isPrivate={!map.public}
-                      name={map["mapName"]}
-                      description={map.description}
-                      map={map}
-                      duplicateAction={() => {
-                        handleSelectMapToDuplicate(map);
-                      }}
-                    />
+                {loading ? (
+                  <Grid.Col
+                    style={{
+                      height: "auto",
+                      display: "flex",
+                      justifyContent: "center",
+                      alignItems: "center",
+                    }}
+                  >
+                    <Loader color="blue" />
                   </Grid.Col>
-                ))}
+                ) : (
+                  maps?.slice(start,end).map((map) => (
+                    <Grid.Col span={cardSpan}>
+                      <MapCard
+                        isPrivate={!map.public}
+                        name={map["mapName"]}
+                        description={map.description}
+                        map={map}
+                        duplicateAction={() => {
+                          handleSelectMapToDuplicate(map);
+                        }}
+                      />
+                    </Grid.Col>
+                  ))
+                )}
               </Grid>
             </Stack>
           </Box>
-          <Pagination total={10} id="pagination" />
+            <Pagination disabled={loading} total={Math.ceil((maps?.length ?? 0) / pageTotal)} id="pagination" onChange={setPage} />
         </Stack>
       </div>
+
       <Footer />
     </>
   );

--- a/client/src/components/browsing/HomeScreen.tsx
+++ b/client/src/components/browsing/HomeScreen.tsx
@@ -3,7 +3,7 @@ import { Group, Text, Stack, Box, Grid } from "@mantine/core";
 import MapCard from "./MapCard";
 import NavBar from "../common/Navbar";
 import Footer from "../common/Footer";
-import { Link, Route } from "react-router-dom";
+import { Link, Route, useLocation } from "react-router-dom";
 import { useState } from "react";
 import { useEffect } from "react";
 import { getMaps } from "../../api/MapApiAccessor";
@@ -15,10 +15,10 @@ import { useDisclosure } from "@mantine/hooks";
 import DuplicateMapModal from "../modals/DuplicateMapModal";
 
 const HomePage = () => {
-  const [map, setMap] = useState<Map>();
   const [maps, setMaps] = useState<Map[]>([]);
+  const location = useLocation();
   const [yourMaps, setYourMaps] = useState<Map[]>([]);
-  const [selectedMapToDuplicate, setSelectedMapToDuplicate] = useState<Map>();
+  
   const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
 
   useEffect(() => {
@@ -29,12 +29,11 @@ const HomePage = () => {
   // Create a getMap function that takes in a mapId and returns the map object
   const getMap = async () => {
     try {
-      const res = await getMap()
-    }
-    catch (error) {
+      const res = await getMap();
+    } catch (error) {
       console.error("Error updating data:", error);
     }
-  }
+  };
 
   const getPublicMaps = async () => {
     try {
@@ -42,12 +41,8 @@ const HomePage = () => {
       console.log("Public Maps fetched successfully:", responseData);
       setMaps(responseData.splice(0, 8));
     } catch (error) {
-      console.error("Error updating data:", error);
+      console.error("Error fetching Maps:", error);
     }
-    console.log('wewaksd');
-    yourMaps.map((map, i) => (console.log(map)));
-
-    // MAP HAS THE _ID!!!!!
   };
 
   const getYourMaps = async () => {
@@ -63,12 +58,12 @@ const HomePage = () => {
     }
   };
 
-  const handleSelectMapToDuplicate = (map:Map) => {
+  const handleSelectMapToDuplicate = (map: Map) => {
     console.log("Selected map to duplicate:", map);
-    setSelectedMapToDuplicate(map);
+    // setSelectedMapToDuplicate(map);
+    location.state = map;
     setDuplicateModal.open();
-  }
-
+  };
 
   const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
   return (
@@ -76,7 +71,6 @@ const HomePage = () => {
       <DuplicateMapModal
         opened={duplicateModalOpened}
         onClose={setDuplicateModal.close}
-        map={selectedMapToDuplicate}
       />
       <NavBar></NavBar>
       <div id="content">
@@ -102,13 +96,16 @@ const HomePage = () => {
               <Grid style={{ textAlign: "initial" }}>
                 {yourMaps.map((map, i) => (
                   <Grid.Col span={cardSpan}>
-                      <MapCard
-                        id={map._id}
-                        name={map.mapName}
-                        description={map.description}
-                        isPrivate={!map.public}
-                        map={map}
-                      />
+                    <MapCard
+                      id={map._id}
+                      name={map.mapName}
+                      description={map.description}
+                      isPrivate={!map.public}
+                      map={map}
+                      duplicateAction={() => {
+                        handleSelectMapToDuplicate(map);
+                      }}
+                    />
                   </Grid.Col>
                 ))}
               </Grid>
@@ -134,7 +131,7 @@ const HomePage = () => {
                 </Link>
               </Group>
               <Grid style={{ textAlign: "initial" }}>
-                {maps.map((map) => ( 
+                {maps.map((map) => (
                   <Grid.Col span={cardSpan}>
                     <MapCard
                       id={map._id}
@@ -142,7 +139,9 @@ const HomePage = () => {
                       name={map["mapName"]}
                       description={map.description}
                       map={map}
-                      duplicateAction={() => {handleSelectMapToDuplicate(map)}}
+                      duplicateAction={() => {
+                        handleSelectMapToDuplicate(map);
+                      }}
                     />
                   </Grid.Col>
                 ))}

--- a/client/src/components/browsing/HomeScreen.tsx
+++ b/client/src/components/browsing/HomeScreen.tsx
@@ -85,16 +85,14 @@ const HomePage = () => {
               <Grid style={{ textAlign: "initial" }}>
                 {yourMaps.map((map, i) => (
                   <Grid.Col span={cardSpan}>
-                    <Link to="/selected">
                       <MapCard
-                        id={`MyMapCard${i + 1}`}
+                        id={map._id}
                         name={map.mapName}
                         description={map.description}
                         isPrivate={!map.public}
                         map={map}
                         duplicateAction={() => {handleSelectMapToDuplicate(map)}}
                       />
-                    </Link>
                   </Grid.Col>
                 ))}
               </Grid>
@@ -123,6 +121,7 @@ const HomePage = () => {
                 {maps.map((map) => (
                   <Grid.Col span={cardSpan}>
                     <MapCard
+                      id={map._id}
                       isPrivate={!map.public}
                       name={map["mapName"]}
                       description={map.description}

--- a/client/src/components/browsing/MapCard.tsx
+++ b/client/src/components/browsing/MapCard.tsx
@@ -47,6 +47,7 @@ const MapCard: React.FC<MapCardProps> = ({
         // e.stopde
         navigate(`/map/${id}`, { state: map });
       }}
+      style={{height: "300px"}}
     >
       <Card.Section>
         <Image
@@ -61,7 +62,7 @@ const MapCard: React.FC<MapCardProps> = ({
       <Text size="9px" ta="left">
         Luffy • {formatDate(map?.creationDate ?? "2023-11-20T02:57:13.344+00:00")}
       </Text>
-      <Text size="10px" ta="left" id="mapDescription" lineClamp={4}>
+      <Text size="10px" ta="left" id="mapDescription" lineClamp={3}>
         {description}
       </Text>
       <Group justify="space-between" mt="md" mb="xs">

--- a/client/src/components/browsing/MapCard.tsx
+++ b/client/src/components/browsing/MapCard.tsx
@@ -44,7 +44,8 @@ const MapCard: React.FC<MapCardProps> = ({
       withBorder
       className="card cursor-pointer"
       onClick={(e) => {
-        navigate(`/map/${id}`);
+        // e.stopde
+        navigate(`/map/${id}`, { state: map });
       }}
     >
       <Card.Section>

--- a/client/src/components/browsing/MapCard.tsx
+++ b/client/src/components/browsing/MapCard.tsx
@@ -42,7 +42,10 @@ const MapCard: React.FC<MapCardProps> = ({
       padding="xl"
       radius="md"
       withBorder
-      className="card"
+      className="card cursor-pointer"
+      onClick={(e) => {
+        navigate(`/map/${id}`);
+      }}
     >
       <Card.Section>
         <Image
@@ -98,6 +101,7 @@ const MapCard: React.FC<MapCardProps> = ({
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  e.stopPropagation();
                   downloadAs?.("PNG");
                 }}
               >
@@ -106,6 +110,7 @@ const MapCard: React.FC<MapCardProps> = ({
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  e.stopPropagation();
                   downloadAs?.("JPEG");
                 }}
               >
@@ -114,6 +119,7 @@ const MapCard: React.FC<MapCardProps> = ({
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  e.stopPropagation();
                   downloadAs?.("JEMS");
                 }}
               >
@@ -122,6 +128,7 @@ const MapCard: React.FC<MapCardProps> = ({
               <Menu.Item
                 onClick={(e) => {
                   e.preventDefault();
+                  e.stopPropagation();
                   duplicateAction?.();
                 }}
               >

--- a/client/src/components/browsing/MyMaps.tsx
+++ b/client/src/components/browsing/MyMaps.tsx
@@ -1,14 +1,50 @@
 import "./css/myMaps.css";
 import { Text, Pagination, Stack, Box, Group, Grid } from "@mantine/core";
-import { Link } from "react-router-dom";
 import MapCard from "./MapCard";
 import NavBar from "../common/Navbar";
 import Footer from "../common/Footer";
-const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
+import { useEffect, useState } from "react";
+import { Map } from "../../utils/models/Map";
+import { getMaps } from "../../api/MapApiAccessor";
+import { useDisclosure } from "@mantine/hooks";
+import DuplicateMapModal from "../modals/DuplicateMapModal";
 
+const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
 function MyMaps() {
+  const [yourMaps, setYourMaps] = useState<Map[]>([]);
+  const [selectedMapToDuplicate, setSelectedMapToDuplicate] = useState<Map>();
+  const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
+  useEffect(() => {
+    // fetch maps data from backend
+    getYourMaps();
+  }, []);
+
+  const getYourMaps = async () => {
+    try {
+      const responseData = await getMaps({
+        session_token: "652daf32e2225cdfeceea14f",
+        creatorId: "652daf32e2225cdfeceea14f",
+      });
+      console.log("Your Maps fetched successfully:", responseData);
+      setYourMaps(responseData);
+    } catch (error) {
+      console.error("Error updating data:", error);
+    }
+  };
+
+  const handleSelectMapToDuplicate = (map: Map) => {
+    console.log("Selected map to duplicate:", map);
+    setSelectedMapToDuplicate(map);
+    setDuplicateModal.open();
+  };
+
   return (
     <>
+      <DuplicateMapModal
+        opened={duplicateModalOpened}
+        onClose={setDuplicateModal.close}
+        map={selectedMapToDuplicate}
+      />
       <NavBar />
       <div id="content">
         <Stack>
@@ -26,41 +62,20 @@ function MyMaps() {
                 </Text>
               </Group>
               <Grid style={{ textAlign: "initial" }}>
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
-
-                <Grid.Col span={cardSpan}>
-                  <Link to="/selected">
-                    <MapCard isPrivate={false}></MapCard>
-                  </Link>
-                </Grid.Col>
+                {yourMaps.map((map) => (
+                  <Grid.Col span={cardSpan}>
+                    <MapCard
+                      id={map._id}
+                      name={map.mapName}
+                      description={map.description}
+                      isPrivate={!map.public}
+                      map={map}
+                      duplicateAction={() => {
+                        handleSelectMapToDuplicate(map);
+                      }}
+                    />
+                  </Grid.Col>
+                ))}
               </Grid>
             </Stack>
           </Box>

--- a/client/src/components/browsing/MyMaps.tsx
+++ b/client/src/components/browsing/MyMaps.tsx
@@ -4,20 +4,24 @@ import MapCard from "./MapCard";
 import NavBar from "../common/Navbar";
 import Footer from "../common/Footer";
 import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { Map } from "../../utils/models/Map";
 import { getMaps } from "../../api/MapApiAccessor";
 import { useDisclosure } from "@mantine/hooks";
 import DuplicateMapModal from "../modals/DuplicateMapModal";
+import { useSelectedMap } from "../selectedcard/SelectedCardPage";
 
 const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
 function MyMaps() {
-  const [yourMaps, setYourMaps] = useState<Map[]>([]);
-  const [selectedMapToDuplicate, setSelectedMapToDuplicate] = useState<Map>();
-  const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
   useEffect(() => {
     // fetch maps data from backend
     getYourMaps();
   }, []);
+
+  const [yourMaps, setYourMaps] = useState<Map[]>([]);
+  const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
+
+  const location = useLocation();
 
   const getYourMaps = async () => {
     try {
@@ -33,8 +37,7 @@ function MyMaps() {
   };
 
   const handleSelectMapToDuplicate = (map: Map) => {
-    console.log("Selected map to duplicate:", map);
-    setSelectedMapToDuplicate(map);
+    location.state = map;
     setDuplicateModal.open();
   };
 
@@ -43,7 +46,6 @@ function MyMaps() {
       <DuplicateMapModal
         opened={duplicateModalOpened}
         onClose={setDuplicateModal.close}
-        map={selectedMapToDuplicate}
       />
       <NavBar />
       <div id="content">

--- a/client/src/components/browsing/SearchedMaps.tsx
+++ b/client/src/components/browsing/SearchedMaps.tsx
@@ -12,6 +12,7 @@ import {
   Image,
   Loader,
   Pagination,
+  Grid,
 } from "@mantine/core";
 import nothingHere from "../../assets/images/NothingHere.svg";
 import MapCard from "./MapCard";
@@ -34,6 +35,7 @@ const NothingHere = () => {
   );
 };
 
+const cardSpan = { base: 12, sm: 6, md: 6, lg: 4, xl: 3 };
 const SearchedMapsScreen = () => {
   const { search } = useParams();
   const location = useLocation();
@@ -93,25 +95,25 @@ const SearchedMapsScreen = () => {
             </Text>
           </Text>
         </Group>
-        <Group>
+        <Grid style={{ textAlign: "initial" }}>
           {loading ? (
-            <Box
+            <Grid.Col
               style={{
-                width: "100%",
+                height: "auto",
                 display: "flex",
                 justifyContent: "center",
                 alignItems: "center",
               }}
             >
               <Loader color="blue" />
-            </Box>
+            </Grid.Col>
           ) : maps?.length === 0 ? (
             <Box mx="auto">
               <NothingHere />
             </Box>
           ) : (
             maps?.slice(start, end).map((map) => (
-              <Group justify="flex-start">
+              <Grid.Col span={cardSpan}>
                 <MapCard
                   id={map._id}
                   name={map.mapName}
@@ -122,10 +124,10 @@ const SearchedMapsScreen = () => {
                     handleSelectMapToDuplicate(map);
                   }}
                 />
-              </Group>
+              </Grid.Col>
             ))
           )}
-        </Group>
+        </Grid>
         <Group>
           <Pagination
             disabled={loading}

--- a/client/src/components/browsing/SearchedMaps.tsx
+++ b/client/src/components/browsing/SearchedMaps.tsx
@@ -9,6 +9,9 @@ import nothingHere from "../../assets/images/NothingHere.svg";
 import MapCard from "./MapCard";
 import { getMaps } from "../../api/MapApiAccessor";
 import { Map } from "../../utils/models/Map";
+import { useDisclosure } from "@mantine/hooks";
+import DuplicateMapModal from "../modals/DuplicateMapModal";
+
 const NothingHere = () => {
   return (
     <Stack align="center" id="nothingHereStack">
@@ -26,6 +29,7 @@ const NothingHere = () => {
 const SearchedMapsScreen = () => {
   const { search } = useParams();
   const location = useLocation();
+  const [duplicateModalOpened, setDuplicateModal] = useDisclosure(false);
   const [maps, setMaps] = useState<Map[]>([]);
   const navigate = useNavigate();
 
@@ -50,8 +54,19 @@ const SearchedMapsScreen = () => {
     navigate("/");
   }
 
+  const handleSelectMapToDuplicate = (map: Map) => {
+    console.log("Selected map to duplicate:", map);
+    // setSelectedMapToDuplicate(map);
+    location.state = map;
+    setDuplicateModal.open();
+  };
+
   return (
     <>
+      <DuplicateMapModal
+        opened={duplicateModalOpened}
+        onClose={setDuplicateModal.close}
+      />
       <NavBar />
       <div className="container">
         <Group>
@@ -77,8 +92,17 @@ const SearchedMapsScreen = () => {
             </Box>
           ) : (
             maps.map((map) => (
-              <Group justify="flex-start" grow>
-                <MapCard isPrivate={false} name={map["mapName"]} />
+              <Group justify="flex-start">
+                <MapCard
+                  id={map._id}
+                  name={map.mapName}
+                  description={map.description}
+                  isPrivate={!map.public}
+                  map={map}
+                  duplicateAction={() => {
+                    handleSelectMapToDuplicate(map);
+                  }}
+                />
               </Group>
             ))
           )}

--- a/client/src/components/common/Navbar.tsx
+++ b/client/src/components/common/Navbar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mantine/core";
 import jemsLogo from "../../assets/images/logo.png";
 import { Link, useNavigate } from "react-router-dom";
-import { useDisclosure } from "@mantine/hooks";
+import { useDisclosure, useForceUpdate} from "@mantine/hooks";
 import CreateMapModal from "../modals/CreateMapModal";
 import {
   IconLogout,
@@ -148,10 +148,11 @@ export default function NavBar() {
   );
 }
 
+
+
 function SearchBar() {
   // This is the hook that controls the search bar
   const [search, setSearch] = useState("");
-
   // This is the hook that allows us to navigate to different pages
   const navigate = useNavigate();
 
@@ -166,7 +167,8 @@ function SearchBar() {
       // the reason for {state: forceRefresh: true} is because we want
       // to force a refresh of the page incase the user just wants to recieve
       // new updagtes on the results
-      navigate("/maps/search/" + search, { state: { forceRefresh: true } });
+      const searchFor = "/maps/search/" + search
+      navigate(searchFor);
     }
   };
   return (

--- a/client/src/components/hooks/useLoadingData.tsx
+++ b/client/src/components/hooks/useLoadingData.tsx
@@ -17,7 +17,8 @@ import { useState, useEffect } from "react";
  */
 export const useLoadingData = <T = any>(
   fetchDataFunction: (...args: any[]) => Promise<any>,
-  params: any[] = []
+  params: any[] = [],
+  dependencies: any[] = []
 ) => {
   const [data, setData] = useState<T>();
   const [error, setError] = useState<any>(null);
@@ -36,7 +37,7 @@ export const useLoadingData = <T = any>(
       }
     };
     fetchData();
-  }, []);
+  }, dependencies);
 
   return { data, error, loading };
 };

--- a/client/src/components/hooks/useLoadingData.tsx
+++ b/client/src/components/hooks/useLoadingData.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+
+
+/**
+ * `useLoadingData` is a custom React hook that fetches data from an API using a provided fetch function and parameters.
+ * It maintains and returns three state variables: `data`, `error`, and `loading`.
+ *
+ * @param fetchDataFunction - A function that fetches data from an API. This function should return a promise.
+ * @param params - An array of parameters to pass to the `fetchDataFunction`. This is optional.
+ *
+ * @returns An object containing the following properties:
+ * - `data`: The data fetched from the API. Its type is determined by the type parameter `T`. It's `null` by default and after a successful fetch, it will hold the fetched data.
+ * - `error`: Any error that occurred while fetching the data. It's `null` by default and if an error occurs during the fetch, it will hold the error.
+ * - `loading`: A boolean indicating whether the data is currently being fetched. It's `true` by default and becomes `false` once the data has been fetched.
+ *
+ * @template T The type of the data that will be fetched. This can be any valid TypeScript type. The default type is `any`.
+ */
+export const useLoadingData = <T = any>(
+  fetchDataFunction: (...args: any[]) => Promise<any>,
+  params: any[] = []
+) => {
+  const [data, setData] = useState<T>();
+  const [error, setError] = useState<any>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+    console.log("fetching data")
+      try {
+        const res = await fetchDataFunction(...params);
+        setData(res);
+      } catch (error) {
+        setError(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return { data, error, loading };
+};

--- a/client/src/components/hooks/useLoadingData.tsx
+++ b/client/src/components/hooks/useLoadingData.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect } from "react";
  * @param params - An array of parameters to pass to the `fetchDataFunction`. This is optional.
  *
  * @returns An object containing the following properties:
- * - `data`: The data fetched from the API. Its type is determined by the type parameter `T`. It's `null` by default and after a successful fetch, it will hold the fetched data.
+ * - `data`: The data fetched from the API. Its type is determined by the type parameter `T`. It's `undefined` by default and after a successful fetch, it will hold the fetched data.
  * - `error`: Any error that occurred while fetching the data. It's `null` by default and if an error occurs during the fetch, it will hold the error.
  * - `loading`: A boolean indicating whether the data is currently being fetched. It's `true` by default and becomes `false` once the data has been fetched.
  *

--- a/client/src/components/modals/DuplicateMapModal.tsx
+++ b/client/src/components/modals/DuplicateMapModal.tsx
@@ -18,17 +18,14 @@ import { duplicateMap } from "../../api/MapApiAccessor";
 interface DuplicateMapModalProps {
   opened: boolean;
   onClose: () => void;
-  map?: Map;
 }
 
 // The base duplicate map modal with all the logic
 const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
   opened,
   onClose,
-  map,
 }) => {
   const selectedMap = useSelectedMap();
-
   const form = useForm({
     initialValues: {
       mapName: "",
@@ -52,32 +49,17 @@ const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
     },
   });
 
-  const handleMakeCopy = async () => {
-    // console.log("Form values:", form.values);
-    // console.log("Map to duplicate:", map);
-    /*
-    REPLACE THIS LOGIC WITH API ACCESSOR FOR DUPLICATION
-    */
+  const handleMakeCopy = async (map: Map) => {
     try {
       const data = {
-        map_id: map?._id,
-        map_name: form.values.mapName,
+        mapId: map._id.toString(),
+        mapName: form.values.mapName,
         description: form.values.description,
-        public: (form.values.visibility == "Public" ? true : false),
+        isPublic:
+          form.values.visibility.toString() == "Public" ? "true" : "false",
+        creatorId: map.creatorId, //TODO replace this with actual logged in creator id
       };
-
-      // Replace with your API endpoint
-      const response = await fetch(
-        "https://dev-jems-api.miguelmaramara.com/api/maps/duplicate",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer 652daf32e2225cdfeceea14f", // TODO: replace with actual session token
-          },
-          body: JSON.stringify(data),
-        }
-      );
+      await duplicateMap(data);
     } catch (error) {
       console.error("Error duplicating map:", error);
     }
@@ -103,7 +85,7 @@ const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
         centered
         size="lg"
       >
-        <form onSubmit={form.onSubmit((values) => handleMakeCopy())}>
+        <form onSubmit={form.onSubmit((values) => handleMakeCopy(selectedMap))}>
           <Box>
             <Stack justify="flex-start">
               <TextInput
@@ -139,14 +121,6 @@ const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
                 id="duplicate-modal-submit-button"
                 type="submit"
                 style={{ marginLeft: "auto" }}
-                onClick={() =>
-                  callDuplicateMapApi(
-                    selectedMap,
-                    form.values.mapName,
-                    form.values.description,
-                    form.values.visibility.toString()
-                  )
-                }
               >
                 Make copy
               </Button>
@@ -158,29 +132,15 @@ const DuplicateMapModalBase: React.FC<DuplicateMapModalProps> = ({
   );
 };
 
-function callDuplicateMapApi(
-  selectedMap: Map,
-  mapName: string,
-  description: string,
-  isPublic: string
-) {
-  const mapId = selectedMap._id.toString();
-  // TO-DO Replace creatorId with session token in the future
-  const creatorId = selectedMap.creatorId.toString();
-  isPublic == "Public" ? (isPublic = "true") : (isPublic = "false");
-  duplicateMap({ mapId, mapName, description, isPublic, creatorId });
-}
-
 // wrap it in a conditional loading
 const DuplicateMapModal: React.FC<DuplicateMapModalProps> = ({
   opened,
   onClose,
-  map,
 }) => {
   return (
     <>
       {opened && (
-        <DuplicateMapModalBase opened={opened} onClose={onClose} map={map} />
+        <DuplicateMapModalBase opened={opened} onClose={onClose}/>
       )}
     </>
   );

--- a/client/src/components/selectedcard/MapHeader.tsx
+++ b/client/src/components/selectedcard/MapHeader.tsx
@@ -54,7 +54,7 @@ const MapHeader = () => {
         {selectedMap.mapName}
       </Text>
       <Group id="edit">
-        <Link to="/edit" style={{ marginLeft: "auto" }}>
+        <Link to={`/edit/${selectedMap._id}`} style={{ marginLeft: "auto" }}>
           <Button
             leftSection={<IconEdit size={14} />}
             variant="subtle"

--- a/client/src/components/selectedcard/SelectedCardPage.tsx
+++ b/client/src/components/selectedcard/SelectedCardPage.tsx
@@ -20,7 +20,7 @@ export const useSelectedMap = () => {
 const SelectedCardPage = ({}) => {
   const { id } = useParams();
   const [map, setMap] = useState<Map>();
-  
+
   useEffect(() => {
     // fetch map data from backend
     // set map.

--- a/client/src/components/selectedcard/SelectedCardPage.tsx
+++ b/client/src/components/selectedcard/SelectedCardPage.tsx
@@ -32,7 +32,7 @@ const SelectedCardPage = ({}) => {
 
   return (
     <>
-      <NavBar></NavBar>
+      <NavBar/>
       <div id="content">
         <MapHeader></MapHeader>
         <Canvas></Canvas>

--- a/client/src/components/selectedcard/SelectedCardPage.tsx
+++ b/client/src/components/selectedcard/SelectedCardPage.tsx
@@ -5,7 +5,20 @@ import Canvas from "./Canvas";
 import MapAbout from "./MapAbout";
 import Comments from "./Comments";
 import Footer from "../common/Footer";
+
+import { useParams} from "react-router-dom";
+import { useEffect, useState} from "react";
+import { Map } from "../../utils/models/Map";
+
+
 const SelectedCardPage = () => {
+  const { id } = useParams();
+  const [map, setMap] = useState<Map>();
+  useEffect(() => {
+    // fetch map data from backend
+    // set map.
+  },[]);
+  
   return (
     <>
       <NavBar></NavBar>


### PR DESCRIPTION
** IMPORTANT **
DO NOT MERGE THIS REQUEST... if [DuplicateMap rolling out extra features](https://github.com/JEMS-CSE416/JEMS/pull/75) is  NOT MERGED. This pr is dependent on the merge of the pr mentioned above.

**Updates**
- cleaned up code
- Implemented pagination of my maps, discover, and searched maps screen.
- Added a new custom hook called useLoadingData that lets you retrieve data but also lets you know if it's still loading. useful for letting the user know that the data is still loading.


**How to review:**
```
git checkout main
git fetch
git checkout pagination
cd client
npm start
```

1. Go to browser & see something like below: 
<img width="1792" alt="Screenshot 2023-11-25 at 4 37 40 PM" src="https://github.com/JEMS-CSE416/JEMS/assets/76068901/2da62776-80f3-45c5-b14d-42d7940edd71">

2. after a few seconds the browser should display the maps:
<img width="1792" alt="Screenshot 2023-11-25 at 4 38 45 PM" src="https://github.com/JEMS-CSE416/JEMS/assets/76068901/03790d59-9cc8-408d-8431-3eaac2b4fe10">

3. head over to my maps and the same should occur.
<img width="1792" alt="Screenshot 2023-11-25 at 4 39 08 PM" src="https://github.com/JEMS-CSE416/JEMS/assets/76068901/afc6f087-811a-4443-8f62-5c2f3de073c5">

4. head over to discover maps and the same should also happen:
<img width="1792" alt="Screenshot 2023-11-25 at 4 40 23 PM" src="https://github.com/JEMS-CSE416/JEMS/assets/76068901/27065665-e4b4-4e6b-b838-db797a81efa3">

5. finally try to click on different pages via the pagination navigation at the bottom.