### PR TITLE
Create Map Foolproof Design

### DIFF
--- a/client/src/components/common/FileDropZone.tsx
+++ b/client/src/components/common/FileDropZone.tsx
@@ -2,14 +2,17 @@ import { Group, Text, rem } from '@mantine/core';
 import { IconUpload, IconPhoto } from '@tabler/icons-react';
 import { Dropzone, IMAGE_MIME_TYPE } from '@mantine/dropzone';
 import { MAP_TYPES } from '../../utils/global_utils';
+import "./css/fileDropZone.css";
 
 interface FileDropZoneProps {
+  disabled?: boolean;
   fileUploadType: string;
   onFilesDrop: (file: File) => void;
 }
 
-const FileDropZone: React.FC<FileDropZoneProps> = ({ fileUploadType, onFilesDrop, ...props }) => {
+const FileDropZone: React.FC<FileDropZoneProps> = ({ disabled, fileUploadType, onFilesDrop, ...props }) => {
   let acceptedFiles;
+  console.log(disabled, "disabled");
   if(fileUploadType === "IMAGE_UPLOAD"){
     acceptedFiles = IMAGE_MIME_TYPE;
   }else if(fileUploadType === "MAP_UPLOAD"){
@@ -18,11 +21,13 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({ fileUploadType, onFilesDrop
 
   return (
     <Dropzone
+      disabled={disabled? true : false}
       onDrop={(file) => onFilesDrop(file[0])}
       onReject={(file) => console.log('rejected file', file)}
       maxSize={ (2 * 1024) ** 6}
       accept={acceptedFiles}
       multiple={true}
+      className={disabled ? 'disabled' : ''}
       {...props}
     >
       <Group justify="center" gap="xs" mih={220} style={{ pointerEvents: 'none' }}>

--- a/client/src/components/common/css/fileDropZone.css
+++ b/client/src/components/common/css/fileDropZone.css
@@ -1,0 +1,13 @@
+.disabled {
+  background-color: light-dark(
+    var(--mantine-color-gray-0),
+    var(--mantine-color-dark-6)
+  );
+  background-color: var(--mantine-color-gray-0);
+  color: var(--mantine-color-dark-2);
+  cursor: not-allowed;
+
+  & * {
+    color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-3));
+  }
+}

--- a/client/src/components/modals/CreateMapModal.tsx
+++ b/client/src/components/modals/CreateMapModal.tsx
@@ -157,13 +157,13 @@ const CreateMapModalBase: React.FC<CreateMapModalProps> = ({
     const content = jemsjson.map_file_content;
     console.log(form.values.visibility);
     // legacy format
-    if(!content.legend.choroplethLegend?.hue)
+    if (!content.legend.choroplethLegend?.hue)
       content.legend.choroplethLegend = {
-              hue: "#8eb8fa",
-              min: Number.MAX_SAFE_INTEGER,
-              max: Number.MIN_SAFE_INTEGER,
-              items: {},
-            }
+        hue: "#8eb8fa",
+        min: Number.MAX_SAFE_INTEGER,
+        max: Number.MIN_SAFE_INTEGER,
+        items: {},
+      }
     // Create the request body
     const req = {
       map_file_content: {
@@ -317,6 +317,12 @@ const CreateMapModalBase: React.FC<CreateMapModalProps> = ({
 
   // Handle form submission and close the modal
   const handleFormSubmit = async () => {
+    // Check if either a file or a template is selected
+    if (!selectedValue && !file) {
+      // Show an error message
+      alert("Either a file or a template must be selected");
+      return;
+    }
     const req = await createRequest();
 
     // Create the map
@@ -359,6 +365,13 @@ const CreateMapModalBase: React.FC<CreateMapModalProps> = ({
         // Return `null` if it's valid, or an error message if it's invalid
         if (value.trim() === "") {
           return "Description is required";
+        }
+        return null;
+      },
+      visibility: (value) => {
+        // Return `null` if it's valid, or an error message if it's invalid
+        if (value.trim() === "") {
+          return "Visibility is required";
         }
         return null;
       },
@@ -428,6 +441,7 @@ const CreateMapModalBase: React.FC<CreateMapModalProps> = ({
               </Grid.Col>
               <Grid.Col span={7}>
                 <FileDropZone
+                  disabled={selectedValue ? true : false}
                   fileUploadType="MAP_UPLOAD"
                   onFilesDrop={handleFilesDrop}
                 />


### PR DESCRIPTION
**Updates**
Resolving the following issue: https://github.com/JEMS-CSE416/JEMS/issues/98
- added visibility required statement
- added alert if no file/template is chosen
- disabled filedrop zone when t…emplate is selected

**Testing**
- [x] Pulled recent changes from main branch
- [x] Tested via `npm start`

**How to review:**
```
git checkout main
git fetch
git checkout create_map
cd client
npm start

In another terminal window:
cd server
npm run dev
```

1. Go to browser & see something like below when no fields are inputted:
![image](https://github.com/JEMS-CSE416/JEMS/assets/53535722/874ca33b-93f5-496b-9970-83fccc8ab17b)

2. See an alert that notifies you either a file or a template must be selected. Nothing else is clickable until you press ok.
![image](https://github.com/JEMS-CSE416/JEMS/assets/53535722/4feda947-a743-4023-bb0f-ace9f44faf14)

3. Disabled file drop zone when a template is selected
![image](https://github.com/JEMS-CSE416/JEMS/assets/53535722/2dbde09e-8b72-4c6b-a4e4-b16527e5eb5b)

