### PR TITLE
retrospective auth pull request

### DIFF
--- a/client/src/components/browsing/HomeScreen.tsx
+++ b/client/src/components/browsing/HomeScreen.tsx
@@ -10,6 +10,9 @@ import { useDisclosure } from "@mantine/hooks";
 import DuplicateMapModal from "../modals/DuplicateMapModal";
 import { useLoadingData } from "../hooks/useLoadingData";
 import NothingHere from "../common/NothingHere";
+import { notifications } from "@mantine/notifications";
+import { IconX } from "@tabler/icons-react";
+import { useEffect } from "react";
 
 const HomePage = () => {
   const location = useLocation();
@@ -22,6 +25,14 @@ const HomePage = () => {
     getMaps,
     [{ ownedMaps: true }]
   );
+  useEffect( () => {
+    if(location.state?.err401)
+      notifications.show({
+        icon: <IconX />,
+        title: 'Error 401! You aren\'t Authenicated!',
+        message: 'Not authenticated to see that map!',
+      });
+  }, []); // eslint-disable-line
 
   // Create a getMap function that takes in a mapId and returns the map object
   const getMap = async () => {

--- a/client/src/components/selectedcard/SelectedCardPage.tsx
+++ b/client/src/components/selectedcard/SelectedCardPage.tsx
@@ -35,13 +35,13 @@ const SelectedCardPage = ({}) => {
         } catch (error) {
           console.error(error);
         }
-      } else {
-        navigate('/', {state:{err401: true}})
-      }
-    };
+      }     };
+
+    if(!map && !mapLoading)
+      navigate('/home/', {state:{err401: true}})
 
     fetchUser();
-  }, [map, navigate]);
+  }, [map, mapLoading, navigate]);
 
   if (!isLoggedIn) {
     navigate("/login");

--- a/client/src/context/EditContextProvider.tsx
+++ b/client/src/context/EditContextProvider.tsx
@@ -120,7 +120,7 @@ export function EditContextProvider(props: EditContextProviderProps) {
       });
     } catch (error: any) {
       console.error("Error fetching map:", error);
-      navigate('/', {state:{err401: true}})
+      navigate('/home/', {state:{err401: true}})
     }
   };
 


### PR DESCRIPTION
Fixes:
1. https://github.com/JEMS-CSE416/JEMS/issues/112
2. Could access home page unauthenticated by logging in, then logging out, then manually typing in `.../home/` into the address bar
3. Accessing edit page for a map as a non-owner AND accessing selected card page for a private map did not have friendly outputs. added redirects and notifs

**How to review:**
```
go to orca

Attempt to break the code in the above ways:
```